### PR TITLE
removeChorus regex is not working, regex fix

### DIFF
--- a/lib/songs/song.ts
+++ b/lib/songs/song.ts
@@ -124,6 +124,6 @@ export class Song {
     }
 
     removeChorus(lyrics: string): string {
-        return lyrics.replace(/^\[[^\]]+\]$/g, "");
+        return lyrics.replace(/^\[(?:Chorus|Post-Chorus|Pre-Chorus)[\s\S]*?(?:\n\n|(?=[\n]?$(?![\n])))/gm, "");
     }
 }


### PR DESCRIPTION
As per issue #38 
Here's a proposed fix for the removeChorus option. This regex matches Chorus, Post-Chorus and Pre-Chorus blocks, allowing to remove them all.